### PR TITLE
Add Mbed CE support for Freescale Kinetis parts

### DIFF
--- a/boards/frdm_k22f.json
+++ b/boards/frdm_k22f.json
@@ -14,7 +14,8 @@
   },
   "frameworks": [
     "mbed",
-    "zephyr"
+    "zephyr",
+	"mbed-ce"
   ],
   "name": "Freescale Kinetis FRDM-K22F",
   "upload": {

--- a/boards/frdm_k64f.json
+++ b/boards/frdm_k64f.json
@@ -14,6 +14,7 @@
   },
   "frameworks": [
     "mbed",
+	"mbed-ce",
     "zephyr"
   ],
   "name": "Freescale Kinetis FRDM-K64F",

--- a/boards/frdm_k66f.json
+++ b/boards/frdm_k66f.json
@@ -14,7 +14,8 @@
     "svd_path": "MK66F18.svd"
   },
   "frameworks": [
-    "mbed"
+    "mbed",
+	"mbed-ce"
   ],
   "name": "Freescale Kinetis FRDM-K66F",
   "upload": {

--- a/boards/frdm_k82f.json
+++ b/boards/frdm_k82f.json
@@ -10,7 +10,8 @@
   },
   "frameworks": [
     "mbed",
-    "zephyr"
+    "zephyr",
+	"mbed-ce"
   ],
   "name": "Freescale Kinetis FRDM-K82F",
   "upload": {

--- a/boards/frdm_kl25z.json
+++ b/boards/frdm_kl25z.json
@@ -11,7 +11,8 @@
   },
   "frameworks": [
     "mbed",
-    "zephyr"
+    "zephyr",
+	"mbed-ce"
   ],
   "name": "Freescale Kinetis FRDM-KL25Z",
   "upload": {

--- a/boards/frdm_kl43z.json
+++ b/boards/frdm_kl43z.json
@@ -10,7 +10,8 @@
     "svd_path": "MKL43Z4.svd"
   },
   "frameworks": [
-    "mbed"
+    "mbed",
+	"mbed-ce"
   ],
   "name": "Freescale Kinetis FRDM-KL43Z",
   "upload": {

--- a/boards/frdm_kl46z.json
+++ b/boards/frdm_kl46z.json
@@ -10,7 +10,8 @@
     "svd_path": "MKL46Z4.svd"
   },
   "frameworks": [
-    "mbed"
+    "mbed",
+	"mbed-ce"
   ],
   "name": "Freescale Kinetis FRDM-KL46Z",
   "upload": {

--- a/boards/hexiwear.json
+++ b/boards/hexiwear.json
@@ -33,7 +33,8 @@
   },
   "frameworks": [
     "mbed",
-    "zephyr"
+    "zephyr",
+	"mbed-ce"
   ],
   "name": "Hexiwear",
   "upload": {

--- a/builder/frameworks/mbed-ce.py
+++ b/builder/frameworks/mbed-ce.py
@@ -1,0 +1,27 @@
+# Copyright 2014-present PlatformIO <contact@platformio.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Mbed OS Community Edition
+
+https://mbed-ce.dev/
+"""
+
+from os.path import join
+
+from SCons.Script import Import, SConscript
+
+Import("env")
+
+SConscript(
+    join(env.PioPlatform().get_package_dir("framework-mbed-ce"), "tools", "python", "mbed_platformio", "build_mbed_ce.py"))

--- a/builder/main.py
+++ b/builder/main.py
@@ -96,7 +96,6 @@ else:
     target_elf = env.BuildProgram()
     target_firm = env.ElfToBin(join("$BUILD_DIR", "${PROGNAME}"), target_elf)
     env.Depends(target_firm, "checkprogsize")
-   
 
 AlwaysBuild(env.Alias("nobuild", target_firm))
 target_buildprog = env.Alias("buildprog", target_firm, target_firm)

--- a/builder/main.py
+++ b/builder/main.py
@@ -96,6 +96,7 @@ else:
     target_elf = env.BuildProgram()
     target_firm = env.ElfToBin(join("$BUILD_DIR", "${PROGNAME}"), target_elf)
     env.Depends(target_firm, "checkprogsize")
+   
 
 AlwaysBuild(env.Alias("nobuild", target_firm))
 target_buildprog = env.Alias("buildprog", target_firm, target_firm)

--- a/platform.json
+++ b/platform.json
@@ -51,7 +51,7 @@
 	"framework-mbed-ce": {
       "type": "framework",
       "optional": true,
-      "owner": "mbed-ce",
+      "owner": "mbed-ce-project",
       "version": ">=6.99"
     },
     "framework-zephyr": {

--- a/platform.json
+++ b/platform.json
@@ -64,7 +64,7 @@
       "type": "uploader",
       "optional": true,
       "owner": "platformio",
-      "version": "~2.36"
+      "version": "~1.2900.0"
     },
     "tool-jlink": {
       "type": "uploader",

--- a/platform.json
+++ b/platform.json
@@ -24,6 +24,10 @@
       "package": "framework-mbed",
       "script": "builder/frameworks/mbed.py"
     },
+	"mbed-ce": {
+      "package": "framework-mbed-ce",
+      "script": "builder/frameworks/mbed-ce.py"
+    },
     "zephyr": {
       "package": "framework-zephyr",
       "script": "builder/frameworks/zephyr.py"
@@ -44,6 +48,12 @@
       "owner": "platformio",
       "version": "~6.61700.0"
     },
+	"framework-mbed-ce": {
+      "type": "framework",
+      "optional": true,
+      "owner": "mbed-ce",
+      "version": "~7.0"
+    },
     "framework-zephyr": {
       "type": "framework",
       "optional": true,
@@ -54,7 +64,7 @@
       "type": "uploader",
       "optional": true,
       "owner": "platformio",
-      "version": "~1.2900.0"
+      "version": "~2.36"
     },
     "tool-jlink": {
       "type": "uploader",

--- a/platform.json
+++ b/platform.json
@@ -52,7 +52,7 @@
       "type": "framework",
       "optional": true,
       "owner": "mbed-ce",
-      "version": "~7.0"
+      "version": ">=6.99"
     },
     "framework-zephyr": {
       "type": "framework",

--- a/platform.py
+++ b/platform.py
@@ -29,8 +29,13 @@ class FreescalekinetisPlatform(PlatformBase):
     def configure_default_packages(self, variables, targets):
         board = variables.get("board")
         frameworks = variables.get("pioframework", [])
-        if "mbed" in frameworks:
+        if "mbed" in frameworks or "mbed-ce" in frameworks:
             self.packages["toolchain-gccarmnoneeabi"]["version"] = "~1.90201.0"
+            
+        if "mbed-ce" in frameworks:
+            for p in self.packages:
+                if p in ("tool-cmake", "tool-ninja"):
+                    self.packages[p]["optional"] = False
 
         if "zephyr" in frameworks:
             for p in self.packages:
@@ -38,6 +43,7 @@ class FreescalekinetisPlatform(PlatformBase):
                     self.packages[p]["optional"] = False
             if not IS_WINDOWS:
                 self.packages["tool-gperf"]["optional"] = False
+                
 
         jlink_conds = [
             "jlink" in variables.get(option, "")

--- a/platform.py
+++ b/platform.py
@@ -43,7 +43,6 @@ class FreescalekinetisPlatform(PlatformBase):
                     self.packages[p]["optional"] = False
             if not IS_WINDOWS:
                 self.packages["tool-gperf"]["optional"] = False
-                
 
         jlink_conds = [
             "jlink" in variables.get(option, "")


### PR DESCRIPTION
This PR adds support for using Mbed CE with platform-freescalekinetis. See the forum thread for more information: https://community.platformio.org/t/hi-from-mbed-ce-project/48249

BTW, I should note that I ran into some issues testing this on K64F: pyocd does not install unless I pin it to a newer version (and then it can't flash), and nether pyocd nor j-link have good behavior in a debug session. They can start debugging but the call stack isn't visible and trying to step through the code eventually leads to a debugger hang.

I don't think these issues are related to Mbed CE, but they should be looked into.